### PR TITLE
clarify subdomain name is based on the target deployment.

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -15,9 +15,9 @@ Retrieve the [installation scripts from our documentation repository](https://gi
 
 ## Installation
 
-As a `cluster-admin`, run
+As a `cluster-admin`, execute the installation script, replacing `my.openshift.master.default.subdomain` with your subdomain:
 ```
-openshift_master_default_subdomain=my.openshift.master.default.subdomain ./install-kabanero-foundation.sh
+openshift_master_default_subdomain=<my.openshift.master.default.subdomain> ./install-kabanero-foundation.sh
 ```
 
 ## Sample Appsody project with manual Tekton pipeline run


### PR DESCRIPTION
closes: https://github.com/kabanero-io/kabanero-foundation/issues/43, clarifying that the subdomain is a variable based on your cluster.