### PR TITLE
Move kappnav install/uninstall to the install/uninstall script

### DIFF
--- a/scripts/install-kabanero-foundation.sh
+++ b/scripts/install-kabanero-foundation.sh
@@ -17,6 +17,12 @@ then
   read openshift_master_default_subdomain
 fi
 
+# Query for optional components
+if [ -z "$enable_kappnav" ]
+then
+  echo "Would you like to configure KAppNav (yes/no)?"
+  read enable_kappnav
+fi
 
 ### Istio ###
 
@@ -126,3 +132,9 @@ do
   sleep 5
 done
 
+# Install KAppNav if selected
+if [ "$enable_kappnav" == "yes" ]
+then
+  # TODO: On the next release of kabanero-operator, fix this URL to use release notation
+  oc apply -f https://raw.githubusercontent.com/kabanero-io/kabanero-operator/master/deploy/optional.yaml --selector=kabanero.io/component=kappnav
+fi

--- a/scripts/mustgather/kappnav-mustgather.sh
+++ b/scripts/mustgather/kappnav-mustgather.sh
@@ -8,11 +8,11 @@ set -Euox pipefail
 # operator.  That's the component we're searching for currently.
 COMPONENT="kappnavs.charts.helm.k8s.io"
 BIN=oc
-LOGS_DIR=kabanero-debug
+LOGS_DIR="${LOGS_DIR:-kappnav-debug}"
 
 # Describe and Get all api resources of component across cluster
 
-APIRESOURCES=$(${BIN} get crds -o jsonpath="{.items[*].metadata.name}" | tr ' ' '\n' | grep ${COMPONENT})
+APIRESOURCES=$(${BIN} get crds -o jsonpath='{range .items[*]}{@.metadata.namespace}{"\n"}{end}' | uniq)
 
 for APIRESOURCE in ${APIRESOURCES[@]}
 do

--- a/scripts/mustgather/kappnav-mustgather.sh
+++ b/scripts/mustgather/kappnav-mustgather.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+#
+# Run this script to collect debug information
+
+set -Euox pipefail
+
+# Currently KAppNav is using the default generated name for a helm chart
+# operator.  That's the component we're searching for currently.
+COMPONENT="kappnavs.charts.helm.k8s.io"
+BIN=oc
+LOGS_DIR=kabanero-debug
+
+# Describe and Get all api resources of component across cluster
+
+APIRESOURCES=$(${BIN} get crds -o jsonpath="{.items[*].metadata.name}" | tr ' ' '\n' | grep ${COMPONENT})
+
+for APIRESOURCE in ${APIRESOURCES[@]}
+do
+	NAMESPACES=$(${BIN} get ${APIRESOURCE} --all-namespaces=true -o jsonpath="{.items[*].metadata.namespace}")
+	for NAMESPACE in ${NAMESPACES[@]}
+	do
+		mkdir -p ${LOGS_DIR}/${NAMESPACE}/${APIRESOURCE}
+		${BIN} describe ${APIRESOURCE} -n ${NAMESPACE} > ${LOGS_DIR}/${NAMESPACE}/${APIRESOURCE}/describe.log
+		${BIN} get ${APIRESOURCE} -n ${NAMESPACE} -o=yaml > ${LOGS_DIR}/${NAMESPACE}/${APIRESOURCE}/get.yaml
+	done
+done
+
+
+# Collect pod logs, describe & get additional resources
+
+NAMESPACES=(kappnav)
+APIRESOURCES=(configmaps pods routes roles rolebindings serviceaccounts services)
+
+for NAMESPACE in ${NAMESPACES[@]}
+do
+	PODS=$(${BIN} get pods -n ${NAMESPACE} -o jsonpath="{.items[*].metadata.name}")
+	mkdir -p ${LOGS_DIR}/${NAMESPACE}/pods
+	for POD in ${PODS[@]}
+	do
+		${BIN} logs --all-containers=true -n ${NAMESPACE} ${POD} > ${LOGS_DIR}/${NAMESPACE}/pods/${POD}.log
+	done
+	
+	for APIRESOURCE in ${APIRESOURCES[@]}
+	do
+		mkdir -p ${LOGS_DIR}/${NAMESPACE}/${APIRESOURCE}
+		${BIN} describe ${APIRESOURCE} -n ${NAMESPACE} > ${LOGS_DIR}/${NAMESPACE}/${APIRESOURCE}/describe.log
+		${BIN} get ${APIRESOURCE} -n ${NAMESPACE} -o=yaml > ${LOGS_DIR}/${NAMESPACE}/${APIRESOURCE}/get.yaml
+	done
+done
+
+
+# Collect clusterroles and clusterrolebindings
+
+KEY="helm-operator"
+NAMESPACE="kube-system"
+
+APIRESOURCE="clusterroles"
+NAMES=$(${BIN} get ${APIRESOURCE} --selector=kabanero.io/component=kappnav -o jsonpath="{.items[*].metadata.name}" | tr ' ' '\n' | grep ${KEY})
+for NAME in ${NAMES[@]}
+do
+	mkdir -p ${LOGS_DIR}/${NAMESPACE}/${APIRESOURCE}
+	${BIN} describe ${APIRESOURCE} ${NAME} > ${LOGS_DIR}/${NAMESPACE}/${APIRESOURCE}/${NAME}-describe.log
+	${BIN} get ${APIRESOURCE} ${NAME} -o=yaml > ${LOGS_DIR}/${NAMESPACE}/${APIRESOURCE}/${NAME}.yaml
+done
+
+APIRESOURCE="clusterrolebindings"
+NAMES=$(${BIN} get ${APIRESOURCE} --selector=kabanero.io/component=kappnav -o jsonpath="{.items[*].metadata.name}" | tr ' ' '\n' | grep ${KEY})
+for NAME in ${NAMES[@]}
+do
+	mkdir -p ${LOGS_DIR}/${NAMESPACE}/${APIRESOURCE}
+	${BIN} describe ${APIRESOURCE} ${NAME} > ${LOGS_DIR}/${NAMESPACE}/${APIRESOURCE}/${NAME}-describe.log
+	${BIN} get ${APIRESOURCE} ${NAME} -o=yaml > ${LOGS_DIR}/${NAMESPACE}/${APIRESOURCE}/${NAME}.yaml
+done

--- a/scripts/mustgather/mustgather-all.sh
+++ b/scripts/mustgather/mustgather-all.sh
@@ -13,6 +13,7 @@ rm -Rf ${LOGS_DIR}
 ./kabanero-mustgather.sh
 ./knative-mustgather.sh
 ./tekton-mustgather.sh
+LOGS_DIR=$LOGS_DIR ./kappnav-mustgather.sh
 
 tar -zcf ${LOGS_DIR}.tar.gz ${LOGS_DIR}
 rm -Rf ${LOGS_DIR}


### PR DESCRIPTION
Since KAppNav is installed at the cluster level, it should be included in the install script and not managed by the Kabanero operator (which currently only maintains namespace-level things).  Also here is the must-gather for KAppNav.