### PR TITLE
Remove default Kabanero CR instance from the install script.

### DIFF
--- a/scripts/install-kabanero-foundation.sh
+++ b/scripts/install-kabanero-foundation.sh
@@ -136,4 +136,4 @@ fi
 set +x
 echo "The installation script is complete.  You can now create an instance"
 echo "of the Kabanero CR.  To create the default instance:"
-echo "oc apply -f ${SAMPLE_KAB_INSTANCE}"
+echo "oc apply -n ${namespace} -f ${SAMPLE_KAB_INSTANCE}"

--- a/scripts/install-kabanero-foundation.sh
+++ b/scripts/install-kabanero-foundation.sh
@@ -63,16 +63,6 @@ done
 # Grant kabanero SA cluster-admin in order to create Appsody SA cluster-admin from the Collection
 oc adm policy add-cluster-role-to-user cluster-admin -z kabanero-operator -n ${namespace}
 
-# Create instance, and apply default collections.  Early releases did not
-# have default.yaml, so use full.yaml if it does not exist.
-GITHUB_RAW_URL=https://raw.githubusercontent.com/kabanero-io/kabanero-operator/${KABANERO_BRANCH}/config/samples
-if curl --output /dev/null --silent --head --fail "${GITHUB_RAW_URL}/default.yaml"; then
-    oc apply -n ${namespace} -f "${GITHUB_RAW_URL}/default.yaml"
-else
-    oc apply -n ${namespace} -f "${GITHUB_RAW_URL}/full.yaml"
-fi
-
-
 # Need to check KNative Serving CRD is available before proceeding #
 until oc get crd services.serving.knative.dev 
 do
@@ -134,3 +124,16 @@ if [ "$ENABLE_KAPPNAV" == "yes" ]
 then
   oc apply -f https://raw.githubusercontent.com/kabanero-io/kabanero-operator/${KABANERO_BRANCH}/deploy/optional.yaml --selector=kabanero.io/component=kappnav
 fi
+
+# Install complete.  give instructions for how to create an instance.
+GITHUB_RAW_URL=https://raw.githubusercontent.com/kabanero-io/kabanero-operator/${KABANERO_BRANCH}/config/samples
+if curl --output /dev/null --silent --head --fail "${GITHUB_RAW_URL}/default.yaml"; then
+    SAMPLE_KAB_INSTANCE="${GITHUB_RAW_URL}/default.yaml"
+else
+    SAMPLE_KAB_INSTANCE="${GITHUB_RAW_URL}/full.yaml"
+fi
+
+set +x
+echo "The installation script is complete.  You can now create an instance"
+echo "of the Kabanero CR.  To create the default instance:"
+echo "oc apply -f ${SAMPLE_KAB_INSTANCE}"

--- a/scripts/install-kabanero-foundation.sh
+++ b/scripts/install-kabanero-foundation.sh
@@ -135,5 +135,7 @@ fi
 
 set +x
 echo "The installation script is complete.  You can now create an instance"
-echo "of the Kabanero CR.  To create the default instance:"
+echo "of the Kabanero CR.  If you have cloned and curated a collection set,"
+echo "apply the Kabanero CR that you created.  Or, to create the default "
+echo "instance:"
 echo "oc apply -n ${namespace} -f ${SAMPLE_KAB_INSTANCE}"


### PR DESCRIPTION
As discussed in #77, I've removed the Kabanero CR creation from the install script, and replaced it with some text that describes how to do it manually.  Sample text from the end of the script:
```
The installation script is complete.  You can now create an instance
of the Kabanero CR.  To create the default instance:
oc apply -f https://raw.githubusercontent.com/kabanero-io/kabanero-operator/0.2.0-rc.1/config/samples/default.yaml
```