### PR TITLE
add sleep variables 

### DIFF
--- a/scripts/install-kabanero-foundation.sh
+++ b/scripts/install-kabanero-foundation.sh
@@ -8,6 +8,8 @@ set -Eeox pipefail
 
 # Branch/Release of Kabanero #
 KABANERO_BRANCH="${KABANERO_BRANCH:-0.2.0-rc.1}"
+SLEEP5="${SLEEP5:-5}"
+SLEEP1="${SLEEP1:-1}"
 
 # Optional components (yes/no)
 ENABLE_KAPPNAV="${ENABLE_KAPPNAV:-no}"
@@ -57,7 +59,7 @@ oc new-project ${namespace} || true
 # https://github.com/kabanero-io/kabanero-operator/issues/141
 until oc apply -f https://github.com/kabanero-io/kabanero-operator/releases/download/${KABANERO_BRANCH}/kabanero-operators.yaml
 do
-  sleep 5
+  sleep $SLEEP5
 done
 
 # Grant kabanero SA cluster-admin in order to create Appsody SA cluster-admin from the Collection
@@ -66,7 +68,7 @@ oc adm policy add-cluster-role-to-user cluster-admin -z kabanero-operator -n ${n
 # Need to check KNative Serving CRD is available before proceeding #
 until oc get crd services.serving.knative.dev 
 do
-  sleep 1
+  sleep $SlEEP1
 done
 
 
@@ -79,7 +81,7 @@ done
 # Wait for tekton CRDs #
 until oc get crd clustertasks.tekton.dev config.operator.tekton.dev pipelineresources.tekton.dev pipelineruns.tekton.dev pipelines.tekton.dev taskruns.tekton.dev tasks.tekton.dev
 do
-  sleep 5
+  sleep $SLEEP5
 done
 
 release=v0.1.1
@@ -101,7 +103,7 @@ curl -L https://github.com/tektoncd/dashboard/releases/download/${release}/opens
 # https://github.com/tektoncd/dashboard/issues/364
 until oc get clusterrole tekton-dashboard-minimal
 do
-  sleep 1
+  sleep $SLEEP1
 done
 oc patch clusterrole tekton-dashboard-minimal --type json -p='[{"op":"add","path":"/rules/-","value":{"apiGroups":["security.openshift.io"],"resources":["securitycontextconstraints"],"verbs":["use"]}}]'
 oc scale -n kabanero deploy tekton-dashboard --replicas=0
@@ -116,7 +118,7 @@ oc patch configmap config-domain --namespace knative-serving --type='json' --pat
 # Wait for tekton CRDs #
 until oc get crd extensions.dashboard.tekton.dev
 do
-  sleep 5
+  sleep $SLEEP5
 done
 
 # Install KAppNav if selected

--- a/scripts/install-kabanero-foundation.sh
+++ b/scripts/install-kabanero-foundation.sh
@@ -70,7 +70,7 @@ oc adm policy add-cluster-role-to-user cluster-admin -z kabanero-operator -n ${n
 # Need to check KNative Serving CRD is available before proceeding #
 until oc get crd services.serving.knative.dev 
 do
-  sleep $SlEEP_SHORT
+  sleep $SLEEP_SHORT
 done
 
 

--- a/scripts/install-kabanero-foundation.sh
+++ b/scripts/install-kabanero-foundation.sh
@@ -8,8 +8,8 @@ set -Eeox pipefail
 
 # Branch/Release of Kabanero #
 KABANERO_BRANCH="${KABANERO_BRANCH:-0.2.0-rc.1}"
-SLEEP5="${SLEEP5:-5}"
-SLEEP1="${SLEEP1:-1}"
+SLEEP_LONG="${SLEEP_LONG:-5}"
+SLEEP_SHORT="${SLEEP_SHORT:-1}"
 
 # Optional components (yes/no)
 ENABLE_KAPPNAV="${ENABLE_KAPPNAV:-no}"
@@ -59,7 +59,7 @@ oc new-project ${namespace} || true
 # https://github.com/kabanero-io/kabanero-operator/issues/141
 until oc apply -f https://github.com/kabanero-io/kabanero-operator/releases/download/${KABANERO_BRANCH}/kabanero-operators.yaml
 do
-  sleep $SLEEP5
+  sleep $SLEEP_LONG
 done
 
 # Grant kabanero SA cluster-admin in order to create Appsody SA cluster-admin from the Collection
@@ -68,7 +68,7 @@ oc adm policy add-cluster-role-to-user cluster-admin -z kabanero-operator -n ${n
 # Need to check KNative Serving CRD is available before proceeding #
 until oc get crd services.serving.knative.dev 
 do
-  sleep $SlEEP1
+  sleep $SlEEP_SHORT
 done
 
 
@@ -81,7 +81,7 @@ done
 # Wait for tekton CRDs #
 until oc get crd clustertasks.tekton.dev config.operator.tekton.dev pipelineresources.tekton.dev pipelineruns.tekton.dev pipelines.tekton.dev taskruns.tekton.dev tasks.tekton.dev
 do
-  sleep $SLEEP5
+  sleep $SLEEP_LONG
 done
 
 release=v0.1.1
@@ -103,7 +103,7 @@ curl -L https://github.com/tektoncd/dashboard/releases/download/${release}/opens
 # https://github.com/tektoncd/dashboard/issues/364
 until oc get clusterrole tekton-dashboard-minimal
 do
-  sleep $SLEEP1
+  sleep $SLEEP_SHORT
 done
 oc patch clusterrole tekton-dashboard-minimal --type json -p='[{"op":"add","path":"/rules/-","value":{"apiGroups":["security.openshift.io"],"resources":["securitycontextconstraints"],"verbs":["use"]}}]'
 oc scale -n kabanero deploy tekton-dashboard --replicas=0
@@ -118,7 +118,7 @@ oc patch configmap config-domain --namespace knative-serving --type='json' --pat
 # Wait for tekton CRDs #
 until oc get crd extensions.dashboard.tekton.dev
 do
-  sleep $SLEEP5
+  sleep $SLEEP_LONG
 done
 
 # Install KAppNav if selected

--- a/scripts/install-kabanero-foundation.sh
+++ b/scripts/install-kabanero-foundation.sh
@@ -8,6 +8,8 @@ set -Eeox pipefail
 
 # Branch/Release of Kabanero #
 KABANERO_BRANCH="${KABANERO_BRANCH:-0.2.0-rc.1}"
+
+# Over-ride sleep times if necessary for automation
 SLEEP_LONG="${SLEEP_LONG:-5}"
 SLEEP_SHORT="${SLEEP_SHORT:-1}"
 


### PR DESCRIPTION
SVT Install automation requires less error output that is produced by the until do checks.  
Example invokation:
SLEEP_SHORT=60 SLEEP_LONG=120 openshift_master_default_subdomain=api.crc.testing ./install-kabanero-foundation.sh