### PR TITLE
Fix pipelineRef in example-tekton-pipeline-run.sh

### DIFF
--- a/scripts/example-tekton-pipeline-run.sh
+++ b/scripts/example-tekton-pipeline-run.sh
@@ -54,7 +54,7 @@ metadata:
   namespace: kabanero
 spec:
   pipelineRef:
-    name: java-microprofile-build-push-deploy-pipeline
+    name: java-microprofile-build-deploy-pl
   resources:
   - name: git-source
     resourceRef:


### PR DESCRIPTION
I was trying to follow the kabanero docs to manually trigger a pipeline here
https://kabanero.io/docs/ref/general/installation/installing-kabanero-foundation.html#optional-sample-appsody-project-with-manual-tekton-pipeline-run

However my kabanero instance v 0.5.0 does not have the pipeline referenced `java-microprofile-build-push-deploy-pipeline` so the run fails.
Instead, the following pipeline works `java-microprofile-build-deploy-pl`